### PR TITLE
npm install のエラーを修正

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+cd frontend
 npx lint-staged

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint --dir src",
     "lint:fix": "next lint --dir src --fix",
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json}'",
-    "prepare": "husky install"
+    "prepare": "cd .. && husky install frontend/.husky"
   },
   "dependencies": {
     "clsx": "^1.1.1",


### PR DESCRIPTION
## やったこと
#3 のエラーを修正しました．
`husky install` はリポジトリのルートディレクトリからでないと実行できないようなので，frontend ディレクトリで `cd ..` してから `husky install` を実行するようにしました．