### PR TITLE
"users" コレクションを "user_sample" に変更

### DIFF
--- a/backend/model/chat/chat.go
+++ b/backend/model/chat/chat.go
@@ -22,7 +22,7 @@ func NewSlackBotClient(options ...slack.Option) (*slack.Client, error) {
 }
 
 func NewSlackUserClient(ctx context.Context, c *firestore.Client, uuid string, options ...slack.Option) (*slack.Client, error) {
-	dsnap, err := c.Collection("users").Doc(uuid).Get(ctx)
+	dsnap, err := c.Collection("user_sample").Doc(uuid).Get(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/router/handler/join.go
+++ b/backend/router/handler/join.go
@@ -27,7 +27,7 @@ func JoinChannelHandler(c *firestore.Client) http.HandlerFunc {
 		// リクエスト カスタムヘッダに付与されているuuidを取得
 		uuid := j.Data.Authorization
 		// 認証処理．users コレクションに uuid が登録されているかチェック
-		if _, err := c.Collection("users").Doc(uuid).Get(r.Context()); err != nil {
+		if _, err := c.Collection("user_sample").Doc(uuid).Get(r.Context()); err != nil {
 			response.NG(w, response.NotAuthedError)
 			return
 		}

--- a/backend/router/handler/write_firebase.go
+++ b/backend/router/handler/write_firebase.go
@@ -39,7 +39,7 @@ func WriteFirebaseHandler(c *firestore.Client) http.HandlerFunc {
 		// リクエスト カスタムヘッダに付与されているuuidを取得
 		uuid := p.Headers.Authorization
 		// 認証処理．users コレクションに uuid が登録されているかチェック
-		if _, err := c.Collection("users").Doc(uuid).Get(r.Context()); err != nil {
+		if _, err := c.Collection("user_sample").Doc(uuid).Get(r.Context()); err != nil {
 			response.NG(w, response.NotAuthedError)
 			return
 		}


### PR DESCRIPTION
## やったこと

- 認証情報を格納するコレクション名をバックエンド側では `users` としていたが，これをフロントエンドに合わせて `user_sample` に変更