### PR TITLE
Slack App 認証時のアクセスポイントを変更

### DIFF
--- a/frontend/src/pages/signin.tsx
+++ b/frontend/src/pages/signin.tsx
@@ -29,7 +29,7 @@ const Signin: NextPage = () => {
         <Image src="/icon.png" width={250} height={200} />
         <p className="mt-6 text-xl font-bold text-center">アカウントにログイン</p>
         <Link
-          href={`https://slack.com/oauth/authorize?scope=team:read,users:read&client_id=${process.env.SLACK_CLIENT_ID}&state=${router.pathname}`}
+          href={`https://slack.com/oauth/v2/authorize?user_scope=channels:write,chat:write,team:read,users:read&client_id=${process.env.SLACK_CLIENT_ID}&state=${router.pathname}`}
         >
           <a>Slackでサインイン</a>
         </Link>

--- a/server/functions/src/slack.ts
+++ b/server/functions/src/slack.ts
@@ -30,7 +30,7 @@ export const oauthAccess = async (code: string): Promise<oauthAccessResponseType
   };
 
   try {
-    const res = await slackClient.post<oauthAccessResponseType>('oauth.access', requestArgs);
+    const res = await slackClient.post<oauthAccessResponseType>('oauth.v2.access', requestArgs);
     return res.data;
   } catch(e) {
     console.warn('Slack oauth was failed.', e);


### PR DESCRIPTION
Slack App の OAuth 認証時のアクセスポイントを，`oauth.access` から `oauth.v2.access` に変更しました．

参考：https://api.slack.com/methods/oauth.access 
`oauth.access` は古いタイプの Slack App でしか使用できないみたいです．